### PR TITLE
dropping depreciated use_args

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -352,8 +352,8 @@ def main():
     updater = Updater(token=settings.TELEGRAM_BOT_TOKEN, use_context=True)
     dispatcher = updater.dispatcher
 
-    dispatcher.add_handler(CommandHandler("start", deeplink, Filters.regex(r"doctor_\d+$"), pass_args=True))
-    dispatcher.add_handler(CommandHandler("start", deeplink, Filters.regex(r"psychologist_\d+$"), pass_args=True))
+    dispatcher.add_handler(CommandHandler("start", deeplink, Filters.regex(r"doctor_\d+$")))
+    dispatcher.add_handler(CommandHandler("start", deeplink, Filters.regex(r"psychologist_\d+$")))
     dispatcher.add_handler(conv_handler)
     dispatcher.add_handler(CallbackQueryHandler(report_handler, pattern=r"^report_\d+$"))
     dispatcher.add_handler(CommandHandler("stop", stop_conversation))


### PR DESCRIPTION
Since we are using context based handlers, these arguments are depreciated and can be dropped.

[Related docs](https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.commandhandler.html#telegram.ext.CommandHandler.pass_chat_data). Scroll a bit down and you see the "warning"